### PR TITLE
Add correct link for flickr folds

### DIFF
--- a/data/flickr_30kentities/flickr_data_shuffler.py
+++ b/data/flickr_30kentities/flickr_data_shuffler.py
@@ -24,9 +24,9 @@ if __name__ == '__main__':
 
     for fold in fold_files:
 
-        os.mkdir(os.path.join(img_folder, fold))
-        os.mkdir(os.path.join(sent_folder, fold))
-        os.mkdir(os.path.join(ann_folder, fold))
+        os.makedirs(os.path.join(img_folder, fold), exist_ok=True)
+        os.makedirs(os.path.join(sent_folder, fold), exist_ok=True)
+        os.makedirs(os.path.join(ann_folder, fold), exist_ok=True)
 
         print("Now doing fold: ", fold)
         with open(fold_files[fold], encoding='utf-8', mode='r') as f:

--- a/download_data.sh
+++ b/download_data.sh
@@ -7,9 +7,9 @@ cd flickr_30kentities
 
 wget http://shannon.cs.illinois.edu/DenotationGraph/data/flickr30k-images.tar
 wget https://github.com/BryanPlummer/flickr30k_entities/raw/master/annotations.zip
-wget https://github.com/BryanPlummer/flickr30k_entities/blob/master/train.txt
-wget https://github.com/BryanPlummer/flickr30k_entities/blob/master/test.txt
-wget https://github.com/BryanPlummer/flickr30k_entities/blob/master/val.txt
+wget https://raw.githubusercontent.com/BryanPlummer/flickr30k_entities/master/train.txt
+wget https://raw.githubusercontent.com/BryanPlummer/flickr30k_entities/master/test.txt
+wget https://raw.githubusercontent.com/BryanPlummer/flickr30k_entities/master/val.txt
 wget http://shannon.cs.illinois.edu/DenotationGraph/data/flickr30k.tar.gz
 
 


### PR DESCRIPTION
The previous link downloaded the webpage on doing wget.
Adding a new link to the raw content file on github that
downloads the train, test and val folds from the official
github page.